### PR TITLE
Feature/dispatch downstream deployments

### DIFF
--- a/.github/INSTRUCTIONS.md
+++ b/.github/INSTRUCTIONS.md
@@ -10,7 +10,7 @@ This repository contains reusable GitHub workflows that compose `mennotech/githu
 - Do not duplicate low-level signing or deployment logic from `github-actions`.
 - Favor workflow inputs for caller-specific values.
 - Preserve secure defaults, especially certificate cleanup on self-hosted runners.
-- Use pwsh instead of bash as the shell to run code
+- Use pwsh instead of bash as the shell to run code (except validate-workflows.yml)
 
 ## Current Scope
 

--- a/.github/INSTRUCTIONS.md
+++ b/.github/INSTRUCTIONS.md
@@ -10,6 +10,7 @@ This repository contains reusable GitHub workflows that compose `mennotech/githu
 - Do not duplicate low-level signing or deployment logic from `github-actions`.
 - Favor workflow inputs for caller-specific values.
 - Preserve secure defaults, especially certificate cleanup on self-hosted runners.
+- Use pwsh instead of bash as the shell to run code
 
 ## Current Scope
 

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -1,0 +1,305 @@
+---
+# Reusable workflow: Dispatch Downstream Deployments
+#
+# Purpose:
+#   Dispatches repository_dispatch events to one or more downstream repositories
+#   and optionally polls each downstream workflow run until it completes.
+#
+#   Callers pass the DOWNSTREAM_REPOS variable (newline-separated org/repo list),
+#   an event type string, and a GitHub App token secret pair.  The workflow mints
+#   a per-org GitHub App token, builds an org-keyed matrix, then dispatches and
+#   (optionally) polls each repo in parallel across matrix legs.
+#
+# Security:
+#   - App private key secret is never echoed.
+#   - Dispatch token is scoped per-org via actions/create-github-app-token.
+
+name: Dispatch Downstream Deployments
+
+on:
+  workflow_call:
+    inputs:
+      # ------------------------------------------------------------------ #
+      # Downstream repository list                                          #
+      # ------------------------------------------------------------------ #
+      downstream_repos:
+        description: >
+          Newline-separated list of downstream repositories in org/repo format
+          (e.g. "acme/scripts\nacme/tools"). Passed as vars.DOWNSTREAM_REPOS
+          from the calling workflow.
+        required: true
+        type: string
+
+      # ------------------------------------------------------------------ #
+      # Dispatch configuration                                              #
+      # ------------------------------------------------------------------ #
+      event_type:
+        description: >
+          The repository_dispatch event type string to send (e.g.
+          'script-deploy-testing' or 'script-deploy-broad').
+        required: true
+        type: string
+
+      # ------------------------------------------------------------------ #
+      # Polling configuration                                               #
+      # ------------------------------------------------------------------ #
+      wait_for_downstream:
+        description: >
+          When true, poll each downstream repository until its triggered
+          workflow run completes (or the timeout is reached).
+        required: false
+        default: true
+        type: boolean
+
+      wait_timeout_seconds:
+        description: >
+          Maximum seconds to wait for each downstream run to appear and
+          complete. Only used when wait_for_downstream is true.
+        required: false
+        default: 1200
+        type: number
+
+      poll_interval_seconds:
+        description: >
+          Seconds between polling attempts. Only used when
+          wait_for_downstream is true.
+        required: false
+        default: 20
+        type: number
+
+    secrets:
+      app_id:
+        description: 'GitHub App ID used to mint per-org dispatch tokens.'
+        required: true
+
+      app_private_key:
+        description: 'GitHub App private key (PEM format).'
+        required: true
+
+    outputs:
+      dispatch_result:
+        description: >
+          Overall result of the dispatch matrix: 'success' if all repos
+          dispatched and completed successfully, 'failure' otherwise.
+        value: ${{ jobs.summarize.outputs.dispatch_result }}
+
+jobs:
+  # ======================================================================= #
+  # Job 1: Build org-keyed matrix from the downstream_repos input           #
+  # ======================================================================= #
+  build_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - name: Build org matrix
+        id: build
+        shell: bash
+        env:
+          DOWNSTREAM_REPOS: ${{ inputs.downstream_repos }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DOWNSTREAM_REPOS}" ]; then
+            echo "downstream_repos input is empty." >&2
+            exit 1
+          fi
+
+          # Build a JSON object: { "org": ["repo1","repo2"] }
+          json='{}'
+          while IFS= read -r repo; do
+            repo="$(echo "$repo" | xargs)"
+            [ -z "$repo" ] && continue
+
+            org="${repo%%/*}"
+            name="${repo##*/}"
+
+            json="$(echo "$json" | jq --arg org "$org" --arg name "$name" '
+              .[$org] = ((.[$org] // []) + [$name])
+            ')"
+          done <<< "${DOWNSTREAM_REPOS}"
+
+          # Convert to matrix include list: [{"owner":"org","repos":"r1,r2"}]
+          matrix="$(echo "$json" | jq -c '
+            to_entries
+            | map({owner: .key, repos: (.value | join(","))})
+          ')"
+
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  # ======================================================================= #
+  # Job 2: Dispatch (and optionally poll) each org's repos                  #
+  # ======================================================================= #
+  dispatch:
+    needs: build_matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
+    steps:
+      - name: Create app token for ${{ matrix.owner }}
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          owner: ${{ matrix.owner }}
+          repositories: ${{ matrix.repos }}
+
+      - name: Dispatch to repos in ${{ matrix.owner }}
+        id: dispatch_loop
+        shell: bash
+        env:
+          DISPATCH_TOKEN: ${{ steps.app_token.outputs.token }}
+          OWNER: ${{ matrix.owner }}
+          REPOS: ${{ matrix.repos }}
+          EVENT_TYPE: ${{ inputs.event_type }}
+          WAIT_FOR_DOWNSTREAM: ${{ inputs.wait_for_downstream }}
+          WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds }}
+          POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
+          UPSTREAM_REPO: ${{ github.repository }}
+          UPSTREAM_RUN_ID: ${{ github.run_id }}
+          UPSTREAM_RUN_ATTEMPT: ${{ github.run_attempt }}
+          UPSTREAM_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          failures=0
+          successes=0
+          IFS=',' read -r -a repos <<< "${REPOS}"
+
+          for name in "${repos[@]}"; do
+            name="$(echo "$name" | xargs)"
+            [ -z "$name" ] && continue
+
+            correlation_id="${UPSTREAM_RUN_ID}-${UPSTREAM_RUN_ATTEMPT}-${OWNER}-${name}-$(date +%s)"
+            dispatched_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            client_payload="$(jq -cn \
+              --arg correlation_id "${correlation_id}" \
+              --arg upstream_repo "${UPSTREAM_REPO}" \
+              --arg upstream_run_id "${UPSTREAM_RUN_ID}" \
+              --arg upstream_run_attempt "${UPSTREAM_RUN_ATTEMPT}" \
+              --arg upstream_sha "${UPSTREAM_SHA}" \
+              --arg dispatched_at "${dispatched_at}" \
+              '{
+                correlation_id: $correlation_id,
+                upstream_repo: $upstream_repo,
+                upstream_run_id: $upstream_run_id,
+                upstream_run_attempt: $upstream_run_attempt,
+                upstream_sha: $upstream_sha,
+                dispatched_at: $dispatched_at
+              }')"
+
+            echo "Dispatching ${EVENT_TYPE} to ${OWNER}/${name}"
+            response_file="$(mktemp)"
+            status_code="$(curl -sS -o "${response_file}" -w "%{http_code}" -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${OWNER}/${name}/dispatches" \
+              -d "$(jq -cn --arg et "${EVENT_TYPE}" --argjson cp "${client_payload}" \
+                '{event_type: $et, client_payload: $cp}')")"
+
+            if [ "${status_code}" != "204" ]; then
+              echo "Dispatch FAILED for ${OWNER}/${name} (HTTP ${status_code}):"
+              cat "${response_file}"
+              rm -f "${response_file}"
+              failures=$((failures + 1))
+              continue
+            fi
+
+            rm -f "${response_file}"
+            echo "Dispatch OK for ${OWNER}/${name}"
+
+            if [ "${WAIT_FOR_DOWNSTREAM}" != "true" ]; then
+              successes=$((successes + 1))
+              continue
+            fi
+
+            # ---- Poll for downstream run completion ---- #
+            echo "Polling downstream workflow run for ${OWNER}/${name}"
+            timeout_at=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
+            found_run=0
+            run_finished=0
+
+            while [ "$(date +%s)" -lt "${timeout_at}" ]; do
+              runs_json="$(curl -sS \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${OWNER}/${name}/actions/runs?event=repository_dispatch&per_page=50")"
+
+              selected_run="$(echo "${runs_json}" | jq -c --arg since "${dispatched_at}" '
+                .workflow_runs
+                | map(select(.created_at >= $since))
+                | sort_by(.created_at)
+                | reverse
+                | .[0] // empty
+              ')"
+
+              if [ -n "${selected_run}" ]; then
+                found_run=1
+                run_id="$(echo "${selected_run}" | jq -r '.id')"
+                run_name="$(echo "${selected_run}" | jq -r '.name')"
+                run_status="$(echo "${selected_run}" | jq -r '.status')"
+                run_conclusion="$(echo "${selected_run}" | jq -r '.conclusion // "null"')"
+                run_url="$(echo "${selected_run}" | jq -r '.html_url')"
+
+                echo "  run id=${run_id} name=${run_name} status=${run_status} conclusion=${run_conclusion}"
+                echo "  Run URL: ${run_url}"
+
+                if [ "${run_status}" = "completed" ]; then
+                  run_finished=1
+                  if [ "${run_conclusion}" = "success" ]; then
+                    echo "Downstream run succeeded for ${OWNER}/${name}"
+                    successes=$((successes + 1))
+                  else
+                    echo "Downstream run FAILED (${run_conclusion}) for ${OWNER}/${name}"
+                    failures=$((failures + 1))
+                  fi
+                  break
+                fi
+              else
+                remaining=$(( timeout_at - $(date +%s) ))
+                echo "No run found yet for ${OWNER}/${name};" \
+                  "waiting ${POLL_INTERVAL_SECONDS}s (${remaining}s remaining)"
+              fi
+
+              sleep "${POLL_INTERVAL_SECONDS}"
+            done
+
+            if [ "${found_run}" = "0" ]; then
+              echo "Timed out waiting for run to appear for ${OWNER}/${name}"
+              failures=$((failures + 1))
+            elif [ "${run_finished}" = "0" ]; then
+              echo "Timed out waiting for run completion for ${OWNER}/${name}"
+              failures=$((failures + 1))
+            fi
+          done
+
+          echo "Dispatch summary: successes=${successes} failures=${failures}"
+
+          if [ "${failures}" -gt 0 ]; then
+            echo "${failures} dispatch and/or downstream workflow check(s) failed." >&2
+            exit 1
+          fi
+
+  # ======================================================================= #
+  # Job 3: Aggregate result for the workflow-level output                   #
+  # ======================================================================= #
+  summarize:
+    needs: dispatch
+    runs-on: ubuntu-latest
+    if: always()
+    outputs:
+      dispatch_result: ${{ steps.result.outputs.dispatch_result }}
+    steps:
+      - name: Set result output
+        id: result
+        shell: bash
+        env:
+          DISPATCH_RESULT: ${{ needs.dispatch.result }}
+        run: |
+          echo "dispatch_result=${DISPATCH_RESULT}" >> "${GITHUB_OUTPUT}"
+          echo "Dispatch matrix result: ${DISPATCH_RESULT}"

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -85,7 +85,7 @@ on:
 
 jobs:
   # ======================================================================= #
-  # Job 1: Build per-repo matrix from the downstream_repos input             #
+  # Job 1: Build per-repo matrix from the downstream_repos input            #
   # ======================================================================= #
   build_matrix:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
           downstream_repos: ${{ inputs.downstream_repos }}
 
   # ======================================================================= #
-  # Job 2: Dispatch (and optionally poll) each repo                          #
+  # Job 2: Dispatch (and optionally poll) each repo                         #
   # ======================================================================= #
   dispatch:
     needs: build_matrix

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build dispatch payload
         id: payload
-        shell: bash
+        shell: pwsh
         env:
           OWNER: ${{ matrix.owner }}
           REPO: ${{ matrix.repo }}
@@ -129,28 +129,22 @@ jobs:
           UPSTREAM_RUN_ATTEMPT: ${{ github.run_attempt }}
           UPSTREAM_SHA: ${{ github.sha }}
         run: |
-          set -euo pipefail
+            $ErrorActionPreference = 'Stop'
 
-          correlation_id="${UPSTREAM_RUN_ID}-${UPSTREAM_RUN_ATTEMPT}-${OWNER}-${REPO}-$(date +%s)"
-          dispatched_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          client_payload="$(jq -cn \
-            --arg correlation_id "${correlation_id}" \
-            --arg upstream_repo "${UPSTREAM_REPO}" \
-            --arg upstream_run_id "${UPSTREAM_RUN_ID}" \
-            --arg upstream_run_attempt "${UPSTREAM_RUN_ATTEMPT}" \
-            --arg upstream_sha "${UPSTREAM_SHA}" \
-            --arg dispatched_at "${dispatched_at}" \
-            '{
-              correlation_id: $correlation_id,
-              upstream_repo: $upstream_repo,
-              upstream_run_id: $upstream_run_id,
-              upstream_run_attempt: $upstream_run_attempt,
-              upstream_sha: $upstream_sha,
-              dispatched_at: $dispatched_at
-            }')"
+            $unixTimestamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+            $correlationId = "$env:UPSTREAM_RUN_ID-$env:UPSTREAM_RUN_ATTEMPT-$env:OWNER-$env:REPO-$unixTimestamp"
+            $dispatchedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+            $clientPayload = @{
+              correlation_id = $correlationId
+              upstream_repo = $env:UPSTREAM_REPO
+              upstream_run_id = $env:UPSTREAM_RUN_ID
+              upstream_run_attempt = $env:UPSTREAM_RUN_ATTEMPT
+              upstream_sha = $env:UPSTREAM_SHA
+              dispatched_at = $dispatchedAt
+            } | ConvertTo-Json -Compress
 
-          echo "dispatched_at=${dispatched_at}" >> "${GITHUB_OUTPUT}"
-          echo "client_payload=${client_payload}" >> "${GITHUB_OUTPUT}"
+            "dispatched_at=$dispatchedAt" >> $env:GITHUB_OUTPUT
+            "client_payload=$clientPayload" >> $env:GITHUB_OUTPUT
 
       - name: Dispatch event
         id: dispatch_event
@@ -164,14 +158,14 @@ jobs:
 
       - name: Fail on dispatch error
         if: ${{ steps.dispatch_event.outputs.success != 'true' }}
-        shell: bash
+        shell: pwsh
         env:
           OWNER: ${{ matrix.owner }}
           REPO: ${{ matrix.repo }}
           STATUS_CODE: ${{ steps.dispatch_event.outputs.status_code }}
         run: |
-          echo "Dispatch failed for ${OWNER}/${REPO} with HTTP ${STATUS_CODE}" >&2
-          exit 1
+            $ErrorActionPreference = 'Stop'
+            throw "Dispatch failed for $env:OWNER/$env:REPO with HTTP $env:STATUS_CODE"
 
       - name: Wait for downstream run
         id: wait_run
@@ -187,7 +181,7 @@ jobs:
 
       - name: Fail on downstream timeout or failure
         if: ${{ inputs.wait_for_downstream && steps.dispatch_event.outputs.success == 'true' }}
-        shell: bash
+        shell: pwsh
         env:
           OWNER: ${{ matrix.owner }}
           REPO: ${{ matrix.repo }}
@@ -195,20 +189,20 @@ jobs:
           CONCLUSION: ${{ steps.wait_run.outputs.conclusion }}
           RUN_URL: ${{ steps.wait_run.outputs.run_url }}
         run: |
-          set -euo pipefail
+            $ErrorActionPreference = 'Stop'
 
-          if [ "${TIMED_OUT}" = "true" ]; then
-            echo "Timed out waiting for downstream run for ${OWNER}/${REPO}" >&2
-            exit 1
-          fi
+            if ($env:TIMED_OUT -eq 'true') {
+              throw "Timed out waiting for downstream run for $env:OWNER/$env:REPO"
+            }
 
-          if [ "${CONCLUSION}" != "success" ]; then
-            echo "Downstream run failed for ${OWNER}/${REPO} (conclusion=${CONCLUSION})" >&2
-            if [ -n "${RUN_URL}" ]; then
-              echo "Run URL: ${RUN_URL}" >&2
-            fi
-            exit 1
-          fi
+            if ($env:CONCLUSION -ne 'success') {
+              $message = "Downstream run failed for $env:OWNER/$env:REPO (conclusion=$env:CONCLUSION)"
+              if (-not [string]::IsNullOrWhiteSpace($env:RUN_URL)) {
+                $message = "$message`nRun URL: $env:RUN_URL"
+              }
+
+              throw $message
+            }
 
   # ======================================================================= #
   # Job 3: Aggregate result for the workflow-level output                   #
@@ -222,9 +216,10 @@ jobs:
     steps:
       - name: Set result output
         id: result
-        shell: bash
+        shell: pwsh
         env:
           DISPATCH_RESULT: ${{ needs.dispatch.result }}
         run: |
-          echo "dispatch_result=${DISPATCH_RESULT}" >> "${GITHUB_OUTPUT}"
-          echo "Dispatch matrix result: ${DISPATCH_RESULT}"
+            $ErrorActionPreference = 'Stop'
+            "dispatch_result=$env:DISPATCH_RESULT" >> $env:GITHUB_OUTPUT
+            Write-Host "Dispatch matrix result: $env:DISPATCH_RESULT"

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -92,34 +92,11 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - name: Build org matrix
+      - name: Build repo matrix
         id: build
-        shell: bash
-        env:
-          DOWNSTREAM_REPOS: ${{ inputs.downstream_repos }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${DOWNSTREAM_REPOS}" ]; then
-            echo "downstream_repos input is empty." >&2
-            exit 1
-          fi
-
-          # Build a matrix include list: [{"owner":"org","repo":"name"}]
-          matrix='[]'
-          while IFS= read -r repo; do
-            repo="$(echo "$repo" | xargs)"
-            [ -z "$repo" ] && continue
-
-            org="${repo%%/*}"
-            name="${repo##*/}"
-
-            matrix="$(echo "$matrix" | jq --arg org "$org" --arg name "$name" '
-              . + [{owner: $org, repo: $name}]
-            ')"
-          done <<< "${DOWNSTREAM_REPOS}"
-
-          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+        uses: mennotech/github-actions/build-repo-matrix@feature/dispatch-repository-event
+        with:
+          downstream_repos: ${{ inputs.downstream_repos }}
 
   # ======================================================================= #
   # Job 2: Dispatch (and optionally poll) each repo                          #

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Build repo matrix
         id: build
-        uses: mennotech/github-actions/build-repo-matrix@feature/dispatch-repository-event
+        uses: mennotech/github-actions/build-repo-matrix@v1
         with:
           downstream_repos: ${{ inputs.downstream_repos }}
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Dispatch event
         id: dispatch_event
-        uses: mennotech/github-actions/dispatch-repository-event@feature/dispatch-repository-event
+        uses: mennotech/github-actions/dispatch-repository-event@v1
         with:
           token: ${{ steps.app_token.outputs.token }}
           owner: ${{ matrix.owner }}
@@ -170,7 +170,7 @@ jobs:
       - name: Wait for downstream run
         id: wait_run
         if: ${{ inputs.wait_for_downstream && steps.dispatch_event.outputs.success == 'true' }}
-        uses: mennotech/github-actions/wait-for-downstream-run@feature/dispatch-repository-event
+        uses: mennotech/github-actions/wait-for-downstream-run@v1
         with:
           token: ${{ steps.app_token.outputs.token }}
           owner: ${{ matrix.owner }}

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -68,11 +68,11 @@ on:
         type: number
 
     secrets:
-      app_id:
+      dispatch_app_id:
         description: 'GitHub App ID used to mint per-org dispatch tokens.'
         required: true
 
-      app_private_key:
+      dispatch_private_key:
         description: 'GitHub App private key (PEM format).'
         required: true
 
@@ -113,8 +113,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.app_id }}
-          private-key: ${{ secrets.app_private_key }}
+          app-id: ${{ secrets.dispatch_app_id }}
+          private-key: ${{ secrets.dispatch_private_key }}
           owner: ${{ matrix.owner }}
           repositories: ${{ matrix.repo }}
 

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -6,9 +6,9 @@
 #   and optionally polls each downstream workflow run until it completes.
 #
 #   Callers pass the DOWNSTREAM_REPOS variable (newline-separated org/repo list),
-#   an event type string, and a GitHub App token secret pair.  The workflow mints
-#   a per-org GitHub App token, builds an org-keyed matrix, then dispatches and
-#   (optionally) polls each repo in parallel across matrix legs.
+#   an event type string, and a GitHub App token secret pair. The workflow mints
+#   a per-repo GitHub App token and delegates dispatch/poll mechanics to
+#   composite actions from mennotech/github-actions.
 #
 # Security:
 #   - App private key secret is never echoed.
@@ -85,7 +85,7 @@ on:
 
 jobs:
   # ======================================================================= #
-  # Job 1: Build org-keyed matrix from the downstream_repos input           #
+  # Job 1: Build per-repo matrix from the downstream_repos input             #
   # ======================================================================= #
   build_matrix:
     runs-on: ubuntu-latest
@@ -105,8 +105,8 @@ jobs:
             exit 1
           fi
 
-          # Build a JSON object: { "org": ["repo1","repo2"] }
-          json='{}'
+          # Build a matrix include list: [{"owner":"org","repo":"name"}]
+          matrix='[]'
           while IFS= read -r repo; do
             repo="$(echo "$repo" | xargs)"
             [ -z "$repo" ] && continue
@@ -114,21 +114,15 @@ jobs:
             org="${repo%%/*}"
             name="${repo##*/}"
 
-            json="$(echo "$json" | jq --arg org "$org" --arg name "$name" '
-              .[$org] = ((.[$org] // []) + [$name])
+            matrix="$(echo "$matrix" | jq --arg org "$org" --arg name "$name" '
+              . + [{owner: $org, repo: $name}]
             ')"
           done <<< "${DOWNSTREAM_REPOS}"
-
-          # Convert to matrix include list: [{"owner":"org","repos":"r1,r2"}]
-          matrix="$(echo "$json" | jq -c '
-            to_entries
-            | map({owner: .key, repos: (.value | join(","))})
-          ')"
 
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
 
   # ======================================================================= #
-  # Job 2: Dispatch (and optionally poll) each org's repos                  #
+  # Job 2: Dispatch (and optionally poll) each repo                          #
   # ======================================================================= #
   dispatch:
     needs: build_matrix
@@ -138,26 +132,21 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
     steps:
-      - name: Create app token for ${{ matrix.owner }}
+      - name: Create app token for ${{ matrix.owner }}/${{ matrix.repo }}
         id: app_token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.app_private_key }}
           owner: ${{ matrix.owner }}
-          repositories: ${{ matrix.repos }}
+          repositories: ${{ matrix.repo }}
 
-      - name: Dispatch to repos in ${{ matrix.owner }}
-        id: dispatch_loop
+      - name: Build dispatch payload
+        id: payload
         shell: bash
         env:
-          DISPATCH_TOKEN: ${{ steps.app_token.outputs.token }}
           OWNER: ${{ matrix.owner }}
-          REPOS: ${{ matrix.repos }}
-          EVENT_TYPE: ${{ inputs.event_type }}
-          WAIT_FOR_DOWNSTREAM: ${{ inputs.wait_for_downstream }}
-          WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds }}
-          POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
+          REPO: ${{ matrix.repo }}
           UPSTREAM_REPO: ${{ github.repository }}
           UPSTREAM_RUN_ID: ${{ github.run_id }}
           UPSTREAM_RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -165,123 +154,82 @@ jobs:
         run: |
           set -euo pipefail
 
-          failures=0
-          successes=0
-          IFS=',' read -r -a repos <<< "${REPOS}"
+          correlation_id="${UPSTREAM_RUN_ID}-${UPSTREAM_RUN_ATTEMPT}-${OWNER}-${REPO}-$(date +%s)"
+          dispatched_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          client_payload="$(jq -cn \
+            --arg correlation_id "${correlation_id}" \
+            --arg upstream_repo "${UPSTREAM_REPO}" \
+            --arg upstream_run_id "${UPSTREAM_RUN_ID}" \
+            --arg upstream_run_attempt "${UPSTREAM_RUN_ATTEMPT}" \
+            --arg upstream_sha "${UPSTREAM_SHA}" \
+            --arg dispatched_at "${dispatched_at}" \
+            '{
+              correlation_id: $correlation_id,
+              upstream_repo: $upstream_repo,
+              upstream_run_id: $upstream_run_id,
+              upstream_run_attempt: $upstream_run_attempt,
+              upstream_sha: $upstream_sha,
+              dispatched_at: $dispatched_at
+            }')"
 
-          for name in "${repos[@]}"; do
-            name="$(echo "$name" | xargs)"
-            [ -z "$name" ] && continue
+          echo "dispatched_at=${dispatched_at}" >> "${GITHUB_OUTPUT}"
+          echo "client_payload=${client_payload}" >> "${GITHUB_OUTPUT}"
 
-            correlation_id="${UPSTREAM_RUN_ID}-${UPSTREAM_RUN_ATTEMPT}-${OWNER}-${name}-$(date +%s)"
-            dispatched_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-            client_payload="$(jq -cn \
-              --arg correlation_id "${correlation_id}" \
-              --arg upstream_repo "${UPSTREAM_REPO}" \
-              --arg upstream_run_id "${UPSTREAM_RUN_ID}" \
-              --arg upstream_run_attempt "${UPSTREAM_RUN_ATTEMPT}" \
-              --arg upstream_sha "${UPSTREAM_SHA}" \
-              --arg dispatched_at "${dispatched_at}" \
-              '{
-                correlation_id: $correlation_id,
-                upstream_repo: $upstream_repo,
-                upstream_run_id: $upstream_run_id,
-                upstream_run_attempt: $upstream_run_attempt,
-                upstream_sha: $upstream_sha,
-                dispatched_at: $dispatched_at
-              }')"
+      - name: Dispatch event
+        id: dispatch_event
+        uses: mennotech/github-actions/dispatch-repository-event@feature/dispatch-repository-event
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+          owner: ${{ matrix.owner }}
+          repo: ${{ matrix.repo }}
+          event_type: ${{ inputs.event_type }}
+          client_payload: ${{ steps.payload.outputs.client_payload }}
 
-            echo "Dispatching ${EVENT_TYPE} to ${OWNER}/${name}"
-            response_file="$(mktemp)"
-            status_code="$(curl -sS -o "${response_file}" -w "%{http_code}" -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${OWNER}/${name}/dispatches" \
-              -d "$(jq -cn --arg et "${EVENT_TYPE}" --argjson cp "${client_payload}" \
-                '{event_type: $et, client_payload: $cp}')")"
+      - name: Fail on dispatch error
+        if: ${{ steps.dispatch_event.outputs.success != 'true' }}
+        shell: bash
+        env:
+          OWNER: ${{ matrix.owner }}
+          REPO: ${{ matrix.repo }}
+          STATUS_CODE: ${{ steps.dispatch_event.outputs.status_code }}
+        run: |
+          echo "Dispatch failed for ${OWNER}/${REPO} with HTTP ${STATUS_CODE}" >&2
+          exit 1
 
-            if [ "${status_code}" != "204" ]; then
-              echo "Dispatch FAILED for ${OWNER}/${name} (HTTP ${status_code}):"
-              cat "${response_file}"
-              rm -f "${response_file}"
-              failures=$((failures + 1))
-              continue
+      - name: Wait for downstream run
+        id: wait_run
+        if: ${{ inputs.wait_for_downstream && steps.dispatch_event.outputs.success == 'true' }}
+        uses: mennotech/github-actions/wait-for-downstream-run@feature/dispatch-repository-event
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+          owner: ${{ matrix.owner }}
+          repo: ${{ matrix.repo }}
+          dispatched_at: ${{ steps.payload.outputs.dispatched_at }}
+          timeout_seconds: ${{ inputs.wait_timeout_seconds }}
+          poll_interval_seconds: ${{ inputs.poll_interval_seconds }}
+
+      - name: Fail on downstream timeout or failure
+        if: ${{ inputs.wait_for_downstream && steps.dispatch_event.outputs.success == 'true' }}
+        shell: bash
+        env:
+          OWNER: ${{ matrix.owner }}
+          REPO: ${{ matrix.repo }}
+          TIMED_OUT: ${{ steps.wait_run.outputs.timed_out }}
+          CONCLUSION: ${{ steps.wait_run.outputs.conclusion }}
+          RUN_URL: ${{ steps.wait_run.outputs.run_url }}
+        run: |
+          set -euo pipefail
+
+          if [ "${TIMED_OUT}" = "true" ]; then
+            echo "Timed out waiting for downstream run for ${OWNER}/${REPO}" >&2
+            exit 1
+          fi
+
+          if [ "${CONCLUSION}" != "success" ]; then
+            echo "Downstream run failed for ${OWNER}/${REPO} (conclusion=${CONCLUSION})" >&2
+            if [ -n "${RUN_URL}" ]; then
+              echo "Run URL: ${RUN_URL}" >&2
             fi
-
-            rm -f "${response_file}"
-            echo "Dispatch OK for ${OWNER}/${name}"
-
-            if [ "${WAIT_FOR_DOWNSTREAM}" != "true" ]; then
-              successes=$((successes + 1))
-              continue
-            fi
-
-            # ---- Poll for downstream run completion ---- #
-            echo "Polling downstream workflow run for ${OWNER}/${name}"
-            timeout_at=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
-            found_run=0
-            run_finished=0
-
-            while [ "$(date +%s)" -lt "${timeout_at}" ]; do
-              runs_json="$(curl -sS \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/${OWNER}/${name}/actions/runs?event=repository_dispatch&per_page=50")"
-
-              selected_run="$(echo "${runs_json}" | jq -c --arg since "${dispatched_at}" '
-                .workflow_runs
-                | map(select(.created_at >= $since))
-                | sort_by(.created_at)
-                | reverse
-                | .[0] // empty
-              ')"
-
-              if [ -n "${selected_run}" ]; then
-                found_run=1
-                run_id="$(echo "${selected_run}" | jq -r '.id')"
-                run_name="$(echo "${selected_run}" | jq -r '.name')"
-                run_status="$(echo "${selected_run}" | jq -r '.status')"
-                run_conclusion="$(echo "${selected_run}" | jq -r '.conclusion // "null"')"
-                run_url="$(echo "${selected_run}" | jq -r '.html_url')"
-
-                echo "  run id=${run_id} name=${run_name} status=${run_status} conclusion=${run_conclusion}"
-                echo "  Run URL: ${run_url}"
-
-                if [ "${run_status}" = "completed" ]; then
-                  run_finished=1
-                  if [ "${run_conclusion}" = "success" ]; then
-                    echo "Downstream run succeeded for ${OWNER}/${name}"
-                    successes=$((successes + 1))
-                  else
-                    echo "Downstream run FAILED (${run_conclusion}) for ${OWNER}/${name}"
-                    failures=$((failures + 1))
-                  fi
-                  break
-                fi
-              else
-                remaining=$(( timeout_at - $(date +%s) ))
-                echo "No run found yet for ${OWNER}/${name};" \
-                  "waiting ${POLL_INTERVAL_SECONDS}s (${remaining}s remaining)"
-              fi
-
-              sleep "${POLL_INTERVAL_SECONDS}"
-            done
-
-            if [ "${found_run}" = "0" ]; then
-              echo "Timed out waiting for run to appear for ${OWNER}/${name}"
-              failures=$((failures + 1))
-            elif [ "${run_finished}" = "0" ]; then
-              echo "Timed out waiting for run completion for ${OWNER}/${name}"
-              failures=$((failures + 1))
-            fi
-          done
-
-          echo "Dispatch summary: successes=${successes} failures=${failures}"
-
-          if [ "${failures}" -gt 0 ]; then
-            echo "${failures} dispatch and/or downstream workflow check(s) failed." >&2
             exit 1
           fi
 

--- a/.github/workflows/dispatch-downstream-deployments.yml
+++ b/.github/workflows/dispatch-downstream-deployments.yml
@@ -79,9 +79,16 @@ on:
     outputs:
       dispatch_result:
         description: >
-          Overall result of the dispatch matrix: 'success' if all repos
-          dispatched and completed successfully, 'failure' otherwise.
+          Result of the dispatch matrix job, taken directly from
+          needs.dispatch.result. Possible values are 'success', 'failure',
+          'cancelled', and 'skipped'. When wait_for_downstream is false,
+          'success' only indicates that all dispatch events were sent
+          successfully — it does not reflect whether downstream workflow
+          runs completed or succeeded.
         value: ${{ jobs.summarize.outputs.dispatch_result }}
+
+permissions:
+  contents: read
 
 jobs:
   # ======================================================================= #

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -55,15 +55,27 @@ jobs:
         run: |
           from pathlib import Path
 
-          workflow = Path('.github/workflows/sign-and-deploy-windows.yml').read_text(encoding='utf-8')
-          required_refs = [
-              'mennotech/github-actions/import-codesigning-cert-windows@v1',
-              'mennotech/github-actions/codesign-files-windows@v1',
-              'mennotech/github-actions/deploy-files-windows@v1',
-          ]
+          checks = {
+              '.github/workflows/sign-and-deploy-windows.yml': [
+                  'mennotech/github-actions/import-codesigning-cert-windows@v1',
+                  'mennotech/github-actions/codesign-files-windows@v1',
+                  'mennotech/github-actions/deploy-files-windows@v1',
+              ],
+              '.github/workflows/dispatch-downstream-deployments.yml': [
+                  'mennotech/github-actions/build-repo-matrix@v1',
+                  'mennotech/github-actions/dispatch-repository-event@v1',
+                  'mennotech/github-actions/wait-for-downstream-run@v1',
+              ],
+          }
 
-          missing = [ref for ref in required_refs if ref not in workflow]
-          if missing:
-              raise SystemExit(f'Missing action references: {missing}')
+          all_missing = {}
+          for workflow_path, required_refs in checks.items():
+              content = Path(workflow_path).read_text(encoding='utf-8')
+              missing = [ref for ref in required_refs if ref not in content]
+              if missing:
+                  all_missing[workflow_path] = missing
+
+          if all_missing:
+              raise SystemExit(f'Missing action references: {all_missing}')
 
           print('Reusable workflow references expected published actions.')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this repository will be documented in this file.
 
 ### Notes
 
-- Workflow requires GitHub App credentials (`app_id` and `app_private_key`) to mint per-org dispatch tokens
+- Workflow requires GitHub App credentials (`dispatch_app_id` and `dispatch_private_key`) to mint per-org dispatch tokens
 - Workflow output `dispatch_result` summarizes the overall matrix outcome for callers
 
 ## [1.0.0] - 2026-03-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this repository will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-03-25
+
+### Added
+
+- New reusable workflow `.github/workflows/dispatch-downstream-deployments.yml`
+- Support for dispatching `repository_dispatch` events to multiple downstream repositories via matrix fan-out
+- Optional downstream run polling with configurable timeout and poll interval inputs
+
+### Changed
+
+- Inline scripting in the downstream dispatch workflow now uses `pwsh` instead of `bash`
+
+### Notes
+
+- Workflow requires GitHub App credentials (`app_id` and `app_private_key`) to mint per-org dispatch tokens
+- Workflow output `dispatch_result` summarizes the overall matrix outcome for callers
+
 ## [1.0.0] - 2026-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ All notable changes to this repository will be documented in this file.
 - Support for dispatching `repository_dispatch` events to multiple downstream repositories via matrix fan-out
 - Optional downstream run polling with configurable timeout and poll interval inputs
 
-### Changed
-
-- Inline scripting in the downstream dispatch workflow now uses `pwsh` instead of `bash`
-
 ### Notes
 
 - Workflow requires GitHub App credentials (`dispatch_app_id` and `dispatch_private_key`) to mint per-org dispatch tokens

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ Purpose:
 
 Required secrets:
 
-- `app_id`
-- `app_private_key`
+- `dispatch_app_id`
+- `dispatch_private_key`
 
 Secret mapping example:
 
 ```yaml
 secrets:
-  app_id: ${{ secrets.GH_APP_ID }}
-  app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+  dispatch_app_id: ${{ secrets.GH_APP_ID }}
+  dispatch_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 ```
 
 ## Workflow Inputs
@@ -146,8 +146,8 @@ jobs:
     permissions:
       contents: read
     secrets:
-      app_id: ${{ secrets.GH_APP_ID }}
-      app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      dispatch_app_id: ${{ secrets.GH_APP_ID }}
+      dispatch_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
     with:
       downstream_repos: ${{ vars.DOWNSTREAM_REPOS }}
       event_type: script-deploy-testing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Reusable GitHub Actions workflows for Mennotech deployment pipelines.
 
-This repository holds reusable workflows that orchestrate the low-level actions published in `mennotech/github-actions`. The first workflow in this repository provides an end-to-end Windows pipeline for code signing, signature verification, deployment, and deployment verification.
+This repository holds reusable workflows that orchestrate the low-level actions published in `mennotech/github-actions`. The workflows currently provide:
+
+- A Windows end-to-end pipeline for code signing, signature verification, deployment, and deployment verification.
+- A downstream deployment dispatcher that emits `repository_dispatch` events to one or more repositories and can wait for their workflow completion.
 
 ## Repository Architecture
 
@@ -31,19 +34,45 @@ Purpose:
 - Deploy files to a Windows target directory
 - Run a dry-run deployment check after deployment
 
-## Required Secrets
-
-The reusable workflow expects the caller repository to provide these secrets:
+Required secrets:
 
 - `CODESIGN_PFX_BASE64`
 - `CODESIGN_PFX_PASSWORD`
 
-Pass these secrets explicitly from the caller workflow:
+Secret mapping example:
 
 ```yaml
 secrets:
   CODESIGN_PFX_BASE64: ${{ secrets.CODESIGN_PFX_BASE64 }}
   CODESIGN_PFX_PASSWORD: ${{ secrets.CODESIGN_PFX_PASSWORD }}
+```
+
+### `dispatch-downstream-deployments`
+
+Reusable workflow path:
+
+```yaml
+uses: mennotech/github-workflows/.github/workflows/dispatch-downstream-deployments.yml@v1
+```
+
+Purpose:
+
+- Build a per-repository matrix from a newline-separated downstream repository list
+- Mint scoped GitHub App tokens per downstream owner
+- Dispatch `repository_dispatch` events with correlation metadata
+- Optionally poll and fail fast when a downstream run times out or concludes unsuccessfully
+
+Required secrets:
+
+- `app_id`
+- `app_private_key`
+
+Secret mapping example:
+
+```yaml
+secrets:
+  app_id: ${{ secrets.GH_APP_ID }}
+  app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 ```
 
 ## Workflow Inputs
@@ -60,6 +89,14 @@ secrets:
 - `timestamp_server`: Authenticode timestamp server URL. Default: `http://timestamp.digicert.com`.
 - `robocopy_options`: Comma-separated robocopy options. Default: `/R:2,/W:2,/NDL,/NFL,/NP`.
 - `recurse`: Whether signing should recurse into subdirectories. Default: `true`.
+
+`dispatch-downstream-deployments.yml` supports the following caller inputs:
+
+- `downstream_repos`: Newline-separated `org/repo` list. Required.
+- `event_type`: Downstream `repository_dispatch` event type string. Required.
+- `wait_for_downstream`: Wait for downstream completion. Default: `true`.
+- `wait_timeout_seconds`: Max wait per downstream repo. Default: `1200`.
+- `poll_interval_seconds`: Poll interval while waiting. Default: `20`.
 
 ## Example Consumer Workflow
 
@@ -92,11 +129,39 @@ jobs:
       timestamp_server: http://timestamp.digicert.com
 ```
 
+### Dispatch Downstream Example
+
+```yaml
+name: Dispatch Downstream Deployments
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    uses: mennotech/github-workflows/.github/workflows/dispatch-downstream-deployments.yml@v1
+    permissions:
+      contents: read
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+    with:
+      downstream_repos: ${{ vars.DOWNSTREAM_REPOS }}
+      event_type: script-deploy-testing
+      wait_for_downstream: true
+      wait_timeout_seconds: 1200
+      poll_interval_seconds: 20
+```
+
 ## Design Principles
 
 - Reusable workflows own orchestration and guardrails.
 - Composite actions own implementation details.
 - Application repositories own deployment-specific values.
+- Dispatch workflows emit traceable payloads and surface aggregate outcomes for callers.
 - Certificate cleanup is explicitly enabled by this workflow to avoid leaving certificates on self-hosted runners.
 - This workflow relies on `mennotech/github-actions@v1` for the low-level signing and deployment mechanics.
 - `.github` is excluded by default at the workflow layer, but callers can opt in with `include_github_directory: true` when that content is part of the deployable payload.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Release Targets
 
-- Immutable release tag: `v1.0.0`
+- Immutable release tag: `v1.1.0`
 - Moving major tag for consumers: `v1`
 
 Consumers should reference the major tag:
@@ -11,7 +11,7 @@ Consumers should reference the major tag:
 uses: mennotech/github-workflows/.github/workflows/sign-and-deploy-windows.yml@v1
 ```
 
-## Initial Release Checklist
+## Release Checklist
 
 1. Ensure GitHub Actions is enabled for the repository.
 2. Validate YAML locally with `yamllint .`.
@@ -20,9 +20,9 @@ uses: mennotech/github-workflows/.github/workflows/sign-and-deploy-windows.yml@v
 5. Verify required caller secrets exist: `CODESIGN_PFX_BASE64` and `CODESIGN_PFX_PASSWORD`.
 6. Update `CHANGELOG.md` for the release date and shipped scope.
 7. Merge the release branch with a squash commit.
-8. Create and push annotated tag `v1.0.0` on the release commit.
+8. Create and push annotated tag `v1.1.0` on the release commit.
 9. Create or update tag `v1` to point to the same release commit.
-10. Publish a GitHub Release using the `v1.0.0` notes.
+10. Publish a GitHub Release using the `v1.1.0` notes.
 
 ## Suggested Release Commands
 
@@ -31,9 +31,9 @@ Run these after the release commit is on `main`:
 ```powershell
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.0.0 -m "github-workflows v1.0.0"
+git tag -a v1.1.0 -m "github-workflows v1.1.0"
 git tag -f -a v1 -m "github-workflows v1"
-git push origin v1.0.0
+git push origin v1.1.0
 git push origin v1 --force
 ```
 
@@ -47,12 +47,12 @@ If you prefer not to force-push tags, delete and recreate `v1` only when intenti
 
 ## Release Notes Scope
 
-For `v1.0.0`, the release notes should call out:
+For `v1.1.0`, the release notes should call out:
 
-- First reusable workflow repository for Mennotech
-- Windows `sign-and-deploy` workflow built on `mennotech/github-actions@v1`
-- YAML validation and lint checks in CI
-- Consumer usage pattern for application repositories
+- New reusable `dispatch-downstream-deployments` workflow
+- Matrix-based downstream `repository_dispatch` fan-out
+- Optional wait/poll behavior for downstream workflow completion
+- Use of GitHub App credentials to mint scoped dispatch tokens
 
 ## Consumer Tagging
 


### PR DESCRIPTION
This pull request introduces version 1.1.0 of the repository, featuring a major new reusable workflow for dispatching deployments to downstream repositories. The update adds comprehensive documentation, usage examples, and release instructions for the new workflow, and standardizes scripting to use PowerShell (`pwsh`) instead of Bash for inline steps.

**New workflow and documentation:**

* Added `.github/workflows/dispatch-downstream-deployments.yml`, a reusable workflow that dispatches `repository_dispatch` events to multiple downstream repositories using a matrix strategy, with optional polling for downstream workflow completion.
* Updated `README.md` to document the new workflow, required secrets (`dispatch_app_id`, `dispatch_private_key`), input parameters, and provided a detailed usage example for consumers.

**Release and changelog updates:**

* Bumped release version to `v1.1.0` in `RELEASE.md`, updated release checklist, tagging instructions, and clarified release notes to highlight the new workflow and its capabilities. 
* Added a new section to `CHANGELOG.md` for version 1.1.0, summarizing the new workflow, matrix fan-out, polling support, and scripting changes.

**Best practices and scripting:**

* Updated `.github/INSTRUCTIONS.md` to recommend using `pwsh` instead of `bash` for workflow scripting, ensuring consistency and compatibility.